### PR TITLE
Call channelRoom() instead of hardcoding channel name string [FIX issue #5]

### DIFF
--- a/server/src/channel/create.js
+++ b/server/src/channel/create.js
@@ -1,4 +1,4 @@
-import { ajv, logger, userRoom } from "../util.js";
+import { ajv, logger, userRoom, channelRoom } from "../util.js";
 
 const validate = ajv.compile({
   type: "object",
@@ -41,7 +41,7 @@ export function createChannel({ io, socket, db }) {
     // broadcast to other tabs of the same user
     socket.to(userRoom(socket.userId)).emit("channel:created", channel);
 
-    io.in(userRoom(socket.userId)).socketsJoin(`channel:${channel.id}`);
+    io.in(userRoom(socket.userId)).socketsJoin(channelRoom(channel.id));
 
     callback({
       status: "OK",

--- a/server/src/channel/join.js
+++ b/server/src/channel/join.js
@@ -1,4 +1,4 @@
-import { ajv, logger, userRoom } from "../util.js";
+import { ajv, logger, userRoom, channelRoom } from "../util.js";
 
 const validate = ajv.compile({
   type: "object",
@@ -37,7 +37,7 @@ export function joinChannel({ io, socket, db }) {
     // broadcast to the other tabs of the same user
     socket.to(userRoom(socket.userId)).emit("channel:joined", channel);
 
-    io.in(userRoom(socket.userId)).socketsJoin(`channel:${channel.id}`);
+    io.in(userRoom(socket.userId)).socketsJoin(channelRoom(channel.id));
 
     callback({
       status: "OK",

--- a/server/src/user/reach.js
+++ b/server/src/user/reach.js
@@ -1,4 +1,4 @@
-import { ajv, logger, userRoom } from "../util.js";
+import { ajv, logger, userRoom, channelRoom } from "../util.js";
 
 const validate = ajv.compile({
   type: "object",
@@ -46,7 +46,7 @@ export function reachUser({ io, socket, db }) {
     // broadcast to other tabs of the same user
     socket.to(userRoom(socket.userId)).emit("channel:created", channel);
 
-    io.in(userRoom(socket.userId)).socketsJoin(`channel:${channel.id}`);
+    io.in(userRoom(socket.userId)).socketsJoin(channelRoom(channel.id));
 
     callback({
       status: "OK",


### PR DESCRIPTION
Fix issue #5 by calling the channelRoom() util function instead of hardcoding the channel name string.

All unit tests passing.